### PR TITLE
PIL-2307 Updated Gemfile and Gemfile.lock to use artifactory

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 # If you do not have OpenSSL installed, change
 # the following line to use 'http://'
-source 'https://rubygems.org'
+source 'https://artefacts.tax.service.gov.uk/artifactory/api/gems/gems/'
 
 # For faster file watcher updates on Windows:
 gem 'wdm', '~> 0.1.1', platforms: [:mswin, :mingw]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,5 +1,5 @@
 GEM
-  remote: https://rubygems.org/
+  remote: https://artefacts.tax.service.gov.uk/artifactory/api/gems/gems/
   specs:
     activesupport (7.0.8.7)
       concurrent-ruby (~> 1.0, >= 1.0.2)

--- a/README.md
+++ b/README.md
@@ -36,6 +36,12 @@ Requirements:
 * [Ruby Version Manager][rbenv]
 * [Node Version Manager][nodenv]
 
+After installing ruby, change the gem sources to use HMRC's artefact repository:
+```shell
+gem sources -r https://rubygems.org/
+gem sources -a https://artefacts.tax.service.gov.uk/artifactory/api/gems/gems/
+````
+
 To live preview:
 ```shell
 bundle install


### PR DESCRIPTION
- Replaced the source from rubygems.org to an artifactory URL
- Updated README with instructions on how to change gem sources to HMRC's artefact repository